### PR TITLE
Adds a derived Debug impl for ReadHandle

### DIFF
--- a/src/append/reader.rs
+++ b/src/append/reader.rs
@@ -9,6 +9,7 @@ use alloc::alloc::{Allocator, Global};
 use super::Stele;
 
 /// A `ReadHandle` for a [`Stele`]
+#[derive(Debug)]
 pub struct ReadHandle<T, A: Allocator = Global> {
     pub(crate) handle: Arc<Stele<T, A>>,
 }


### PR DESCRIPTION
`ReadHandle` was missing a `Debug` implementation.

This PR adds it, by just deriving the default implementation, which is probably correct.