### PR TITLE
Small optimization

### DIFF
--- a/src/append.rs
+++ b/src/append.rs
@@ -5,7 +5,7 @@ use self::{reader::ReadHandle, writer::WriteHandle};
 use crate::{
     max_len, split_idx,
     sync::{Arc, AtomicPtr, AtomicUsize},
-    Inner, WORD_SIZE,
+    Inner,
 };
 ///Iterate over a Stele by Reference or by Value (for copy types)
 pub mod iter;
@@ -18,11 +18,11 @@ pub mod writer;
 /// pointers to power-of-two sized blocks of `T` such that the capacity still doubles each time but
 /// there is no need to copy the old data over.
 ///
-/// The trade-off for this is that the [`Stele`] must hold a slot for up to [`usize::BITS`]
+/// The trade-off for this is that the [`Stele`] must hold a slot for up to 32
 /// pointers, which does increase the memory footprint.
 #[derive(Debug)]
 pub struct Stele<T> {
-    inners: [AtomicPtr<Inner<T>>; WORD_SIZE],
+    inners: [AtomicPtr<Inner<T>>; 32],
     len: AtomicUsize,
 }
 
@@ -32,12 +32,23 @@ unsafe impl<T> Send for Stele<T> where T: Send + Sync {}
 unsafe impl<T> Sync for Stele<T> where T: Send + Sync {}
 
 impl<T> Stele<T> {
+
+    //Taken from the standard libraries small vector optimization
+    const INITIAL_SIZE: usize = {
+        match core::mem::size_of::<T>() {
+            1 => 3,
+            //Exclusive ranges are unstable so @ finally has a use
+            i @ 2.. if i < 1024 => 2,
+            _ => 1
+        }
+    };
+
     #[allow(clippy::new_ret_no_self)]
     #[must_use]
     /// Creates a new Stele returns a [`WriteHandle`] and [`ReadHandle`]
     pub fn new() -> (WriteHandle<T>, ReadHandle<T>) {
         let s = Arc::new(Self {
-            inners: [(); WORD_SIZE].map(|_| crate::sync::AtomicPtr::new(null_mut())),
+            inners: [(); 32].map(|_| crate::sync::AtomicPtr::new(null_mut())),
             len: AtomicUsize::new(0),
         });
         let h = WriteHandle {
@@ -47,9 +58,7 @@ impl<T> Stele<T> {
         let r = ReadHandle { handle: s };
         (h, r)
     }
-}
 
-impl<T> Stele<T> {
     /// Creates a pair of handles from an owned Stele after using [`FromIterator`](core::iter::FromIterator)
     pub fn to_handles(self) -> (WriteHandle<T>, ReadHandle<T>) {
         let s = Arc::new(self);
@@ -68,7 +77,7 @@ impl<T> Stele<T> {
         //SAFETY: By only incrementing the index after appending the element we ensure that we never allow reads to access unwritten memory
         //and by the safety contract of `push` we know we aren't writing to the same spot multiple times
         unsafe {
-            if idx.is_power_of_two() || idx == 0 || idx == 1 {
+            if (idx.is_power_of_two() && dbg!(dbg!(outer_idx) > Self::INITIAL_SIZE)) || (outer_idx <= Self::INITIAL_SIZE && self.is_empty()) {
                 self.allocate(outer_idx);
             }
             *self.inners[outer_idx]
@@ -78,28 +87,26 @@ impl<T> Stele<T> {
         self.len.store(idx + 1, Ordering::Release);
     }
 
-    #[cfg(feature = "allocator_api")]
     pub(crate) fn allocate(&self, idx: usize) {
+        if idx == 0 {
+            (0..=Self::INITIAL_SIZE).for_each(|i| {
+                self.inners[i].compare_exchange(
+                    core::ptr::null_mut(),
+                        unsafe { crate::mem::alloc_inner(max_len(i)) },
+                    Ordering::AcqRel,
+                    Ordering::Relaxed)
+                    .expect("The pointer is null because we have just incremented the cap to the head of this pointer");
+            });
+        } else {
         self.inners[idx]
             .compare_exchange(
                 core::ptr::null_mut(),
-                unsafe { crate::mem::alloc_inner(&self.allocator, max_len(idx)) },
+                unsafe { crate::mem::alloc_inner(max_len(idx)) },
                 Ordering::AcqRel,
                 Ordering::Relaxed,
             )
             .expect("The pointer is null because we have just incremented the cap to the head of this pointer");
-    }
-
-    #[cfg(not(feature = "allocator_api"))]
-    pub(crate) fn allocate(&self, idx: usize) {
-        self.inners[idx]
-            .compare_exchange(
-                core::ptr::null_mut(),
-                unsafe { crate::mem::alloc_inner( max_len(idx)) },
-                Ordering::AcqRel,
-                Ordering::Relaxed,
-            )
-            .expect("The pointer is null because we have just incremented the cap to the head of this pointer");
+        }
     }
 
     pub(crate) fn read(&self, idx: usize) -> &T {
@@ -141,7 +148,7 @@ impl<T: Copy> Stele<T> {
 impl<T> core::iter::FromIterator<T> for Stele<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         let s = Stele {
-            inners: [(); WORD_SIZE].map(|_| AtomicPtr::new(null_mut())),
+            inners: [(); 32].map(|_| AtomicPtr::new(null_mut())),
             len: AtomicUsize::new(0),
         };
         for item in iter {
@@ -158,7 +165,7 @@ impl<T> Drop for Stele<T> {
         let size = *self.len.get_mut();
         #[cfg(loom)]
         let size = unsafe { self.len.unsync_load() };
-        let num_inners = WORD_SIZE - size.leading_zeros() as usize;
+        let num_inners = 32_usize.saturating_sub(size.leading_zeros() as usize);
         for idx in 0..num_inners {
             #[cfg(not(loom))]
             unsafe {

--- a/src/append.rs
+++ b/src/append.rs
@@ -77,7 +77,7 @@ impl<T> Stele<T> {
         //SAFETY: By only incrementing the index after appending the element we ensure that we never allow reads to access unwritten memory
         //and by the safety contract of `push` we know we aren't writing to the same spot multiple times
         unsafe {
-            if (idx.is_power_of_two() && dbg!(dbg!(outer_idx) > Self::INITIAL_SIZE)) || (outer_idx <= Self::INITIAL_SIZE && self.is_empty()) {
+            if (idx.is_power_of_two() && outer_idx > Self::INITIAL_SIZE) || (outer_idx <= Self::INITIAL_SIZE && self.is_empty()) {
                 self.allocate(outer_idx);
             }
             *self.inners[outer_idx]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,8 @@ pub use append::writer::WriteHandle;
 pub use append::Stele;
 pub(crate) use mem::Inner;
 
-const WORD_SIZE: usize = usize::BITS as usize;
-
 const fn split_idx(idx: usize) -> (usize, usize) {
-    let outer_idx = WORD_SIZE.saturating_sub(idx.leading_zeros() as usize);
+    let outer_idx = 32_usize.saturating_sub((idx.leading_zeros() as usize).saturating_sub(usize::BITS.saturating_sub(32) as usize));
     let inner_idx = idx.saturating_sub(1 << (outer_idx.saturating_sub(1)));
     (outer_idx, inner_idx)
 }


### PR DESCRIPTION
Reduce Stele to 2^32 maximum elements and preemptively allocate more space